### PR TITLE
MLKitView typing: Hide overriden on-function

### DIFF
--- a/packages/mlkit-core/index.d.ts
+++ b/packages/mlkit-core/index.d.ts
@@ -43,6 +43,11 @@ export declare class MLKitView extends MLKitViewBase {
   requestCameraPermission(): Promise<void>;
   hasCameraPermission(): boolean;
   on(event: 'detection', callback: (args: DetectionEvent) => void, thisArg?: any);
+  // Needed when 'on' method is overriden.
+  /**
+   * @hidden
+   */
+   on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
 }
 
 export function detectWithStillImage(image: any, options?: StillImageDetectionOptions): Promise<{ [key: string]: any }>;

--- a/packages/mlkit-core/index.d.ts
+++ b/packages/mlkit-core/index.d.ts
@@ -47,7 +47,7 @@ export declare class MLKitView extends MLKitViewBase {
   /**
    * @hidden
    */
-   on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
+  on(eventNames: string, callback: (data: EventData) => void, thisArg?: any): void;
 }
 
 export function detectWithStillImage(image: any, options?: StillImageDetectionOptions): Promise<{ [key: string]: any }>;


### PR DESCRIPTION
Getting the following error when registering the viewbase using svelte-native:

```
Types of construct signatures are incompatible.
  Type 'new () => MLKitView' is not assignable to type 'new () => ViewBase'.
    Construct signature return types 'MLKitView' and 'ViewBase' are incompatible.
      The types of 'on' are incompatible between these types.
        Type '(event: "detection", callback: (args: DetectionEvent) => void, thisArg?: any) => any' is not assignable to type '{ (eventNames: string, callback: (data: EventData) => void, thisArg?: any): any; (event: "propertyChange", callback: (data: EventData) => void, thisArg?: any): any; }'.
          Types of parameters 'event' and 'event' are incompatible.
            Type '"propertyChange"' is not assignable to type '"detection"'. ts(2419)
```

![image](https://user-images.githubusercontent.com/13063204/179365298-9c56b21a-52db-45fb-8c16-805fc30f426e.png)

Resolved by adding `@hidden` directive for the overridden on-function.